### PR TITLE
fix weird weekly date range

### DIFF
--- a/src/components/schedule/CourseCalendar.tsx
+++ b/src/components/schedule/CourseCalendar.tsx
@@ -169,7 +169,7 @@ const CourseCalendar = ({
   }, [selectedView, updateRenderRangeText]);
 
   return (
-    <Box display="flex" flexDirection="column" height="100%">
+    <Box display="flex" flexDirection="column" height="100%" width="100%">
       <Stack padding={2} direction={isSmallScreen ? "column" : "row"} alignContent="center" gap={4}>
         <Select
           sx={{ width: isSmallScreen ? "100%" : "30%", maxWidth: "200px" }}
@@ -212,6 +212,8 @@ const CourseCalendar = ({
           timezonesCollapsed: false,
           eventView: ["time"],
           taskView: false,
+          hourStart: 7,
+          hourEnd: 21,
         }}
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/src/components/schedule/CourseCalendar.tsx
+++ b/src/components/schedule/CourseCalendar.tsx
@@ -125,11 +125,12 @@ const CourseCalendar = ({
         date = rangeStart.getDate();
         const endMonth = rangeEnd.getMonth() + 1;
         const endDate = rangeEnd.getDate();
+        const endYear = rangeEnd.getFullYear();
 
         const start = `${year}-${month < 10 ? "0" : ""}${month}-${
           date < 10 ? "0" : ""
         }${date}`;
-        const end = `${year}-${endMonth < 10 ? "0" : ""}${endMonth}-${
+        const end = `${endYear}-${endMonth < 10 ? "0" : ""}${endMonth}-${
           endDate < 10 ? "0" : ""
         }${endDate}`;
         dateRangeText = `${start} ~ ${end}`;

--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -46,20 +46,6 @@ export const convertIntoReadableRange = (rangeString: string): string => {
   if (!rangeString) {
     return "";
   }
-  const monthsShort: string[] = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
 
   function formatDate(date: string): {
     month: string;
@@ -76,7 +62,7 @@ export const convertIntoReadableRange = (rangeString: string): string => {
 
     const [year, month, day] = date.split("-").map((x) => parseInt(x, 10));
     return {
-      month: monthsShort[month - 1],
+      month: getMonthName(month - 1),
       day,
       year,
     };
@@ -86,8 +72,29 @@ export const convertIntoReadableRange = (rangeString: string): string => {
   const start = formatDate(startDate);
   const end = formatDate(endDate);
 
-  return `${start.month} ${start.day} - ${end.day}, ${start.year}`;
+  if (start.year !== end.year) {
+    return `${getShortMonthName(start.month)} ${start.year} - ${getShortMonthName(end.month)} ${end.year}`;
+  }
+  else if (start.month !== end.month) {
+    return `${getShortMonthName(start.month)} - ${getShortMonthName(end.month)}, ${end.year}`;
+  }
+
+  return `${start.month}, ${start.year}`;
 };
+
+// get string month from month index
+function getMonthName(monthIndex: number): string {
+  const date = new Date();
+  date.setMonth(monthIndex);
+  return date.toLocaleString('en-us', { month: 'long' });
+}
+
+function getShortMonthName(month: string): string {
+  const date = new Date(`${month} 1, 2023`); // put random day and year
+  const monthIndex = date.getMonth();
+  date.setMonth(monthIndex);
+  return date.toLocaleString('en-us', { month: 'short' });
+}
 
 // convert time from hhmm to hh:mm
 export const convertToTime = (time: number): string => {


### PR DESCRIPTION
In the Calendar Weekly mode, when the week is between months, the date range text will display both months. When the week is between years, the date range text will display both months and years.

This PR also fixes #37